### PR TITLE
build: Fix build ENOENT file lessons.csv

### DIFF
--- a/csv/index.js
+++ b/csv/index.js
@@ -1,4 +1,5 @@
 import fs from "fs/promises";
+import nodeFs from 'fs';
 import path from "path";
 import { convertArrayToCSV } from "convert-array-to-csv";
 import { getLessons } from "../data/lesson.js";
@@ -38,9 +39,17 @@ async function start() {
   }
 
   const csv = convertArrayToCSV(lessons);
+  const filePath = config.csvPath
 
-  await fs.writeFile(config.csvPath, csv);
-  console.log(`wrote ${lessons.length} rows to ${config.csvPath}`);
+  // If CSV path does not exist, create it
+  if (!nodeFs.existsSync(filePath)) {
+    nodeFs.mkdirSync(filePath, { recursive: true })
+    nodeFs.rmSync(filePath, { recursive: true })
+    nodeFs.closeSync(nodeFs.openSync(filePath, 'w'));
+  }
+
+  await fs.writeFile(filePath, csv);
+  console.log(`wrote ${lessons.length} rows to ${filePath}`);
 }
 
 start();


### PR DESCRIPTION
Currently while deploying this as a nextjs app to vercel, following error comes:

```bash
> csv
--
02:59:33.025 | > node csv/index.js
02:59:33.025 |  
02:59:33.326 | node:internal/process/promises:288
02:59:33.326 | triggerUncaughtException(err, true /* fromPromise */);
02:59:33.327 | ^
02:59:33.327 |  
02:59:33.327 | [Error: ENOENT: no such file or directory, open './out/lessons.csv'] {
02:59:33.327 | errno: -2,
02:59:33.327 | code: 'ENOENT',
02:59:33.329 | syscall: 'open',
02:59:33.329 | path: './out/lessons.csv'
02:59:33.329 | }
02:59:33.329 |  
02:59:33.329 | Node.js v18.13.0
02:59:33.364 | Error: Command "npm run build" exited with 1
02:59:33.641 | BUILD_FAILED: Command "npm run build" exited with 1
```

basically, it is trying to write to file `./out/lessons.csv`, but `out` directory does not exist.


After this fix, if `out` directory does not exists, it will create it